### PR TITLE
Add tracking issue to README.md for long term solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ perform the redirect for us.
 ## Maintenance Notes
 
 This repository will need some ongoing maintenance to continue functioning.  We
-will be exploring a better long term solution, but for now this repo will serve
-our needs for self-service joining of our Slack workspace.
+will be exploring a [better long term
+solution](https://github.com/crossplane/crossplane/issues/3907), but for now
+this repo will serve our needs for self-service joining of our Slack workspace.
 
 Notes on maintaining this repo can be found below:
 


### PR DESCRIPTION
This PR simply updates the README with a link to https://github.com/crossplane/crossplane/issues/3907, where we are tracking a better long term solution for Crossplane Slack invitations.