### PR TITLE
Update Slack invitation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-1rkkaeelc-WKrorO7PAJllVmYTNyodiA" />
+        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-1uddfv0vr-HinGqwk5h2aFrcCKNaS2bQ" />
     </head>
     <body>
-        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-1rkkaeelc-WKrorO7PAJllVmYTNyodiA">Redirecting you to a Crossplane Slack invitation</a></p>
+        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-1uddfv0vr-HinGqwk5h2aFrcCKNaS2bQ">Redirecting you to a Crossplane Slack invitation</a></p>
     </body>
 </html>


### PR DESCRIPTION
This PR simply refreshes the Slack invitation link that this website redirects to. The links do not expire in time, but they do expire after 400 invitations are used.

See https://github.com/crossplane/slack.crossplane.io#maintenance-notes