### PR TITLE
Update slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-21a0717g5-QyW_L08jXsu8vzjz~0XuUQ" />
+        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-23ppkfqfr-fFIlkGl8moLywRbyWXG0wA" />
     </head>
     <body>
-        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-21a0717g5-QyW_L08jXsu8vzjz~0XuUQ">Redirecting you to a Crossplane Slack invitation</a></p>
+        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-23ppkfqfr-fFIlkGl8moLywRbyWXG0wA">Redirecting you to a Crossplane Slack invitation</a></p>
     </body>
 </html>


### PR DESCRIPTION
This PR simply updates the invite link because the previous one ran out of invitations 😞 

Testing was promising for a long term solution, so we should move that to production soon
https://github.com/crossplane/crossplane/issues/3907#issuecomment-1610885694 