### PR TITLE
Update slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-23ppkfqfr-fFIlkGl8moLywRbyWXG0wA" />
+        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/crossplane/shared_invite/zt-26kxm0k2a-esMwXvMpfw8glyoMzukAlQ" />
     </head>
     <body>
-        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-23ppkfqfr-fFIlkGl8moLywRbyWXG0wA">Redirecting you to a Crossplane Slack invitation</a></p>
+        <p><a href="https://join.slack.com/t/crossplane/shared_invite/zt-26kxm0k2a-esMwXvMpfw8glyoMzukAlQ">Redirecting you to a Crossplane Slack invitation</a></p>
     </body>
 </html>


### PR DESCRIPTION
This PR updates the slack invite link to a new link.  As usual, these links don't expire in time, but do expire after 400 invitations.

We should take care of https://github.com/crossplane/crossplane/issues/3907 after Kubecon 😓 